### PR TITLE
Added column aliasing

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -396,7 +396,7 @@ class Query
             $where .= ' AND (';
 
             foreach ($this->search_fields as $field) {
-                $where .= '`' . $field . '` LIKE "%' . esc_sql($this->search_term) . '%" OR ';
+                $where .= '`' . $model::get_column_name( $field ) . '` LIKE "%' . esc_sql($this->search_term) . '%" OR ';
             }
 
             $where = substr($where, 0, -4) . ')';
@@ -404,6 +404,11 @@ class Query
 
         // Where
         foreach ($this->where as $q) {
+			// Anti-alias column if present.
+			if ( isset( $q['column'] ) ) {
+				$q['column']= $model::get_column_name( $q['column'] );
+			}
+
             // where
             if ($q['type'] == 'where') {
                 $where .= ' AND `' . $q['column'] . '` = "' . esc_sql($q['value']) . '"';
@@ -471,7 +476,7 @@ class Query
                 $where .= ' AND (';
 
                 foreach ($q['where'] as $column => $value) {
-                    $where .= '`' . $column . '` = "' . esc_sql($value) . '" OR ';
+                    $where .= '`' . $model::get_column_name( $column ) . '` = "' . esc_sql($value) . '" OR ';
                 }
 
                 $where = substr($where, 0, -5) . ')';
@@ -482,7 +487,7 @@ class Query
                 $where .= ' AND (';
 
                 foreach ($q['where'] as $column => $value) {
-                    $where .= '`' . $column . '` = "' . esc_sql($value) . '" AND ';
+                    $where .= '`' . $model::get_column_name( $column ) . '` = "' . esc_sql($value) . '" AND ';
                 }
 
                 $where = substr($where, 0, -5) . ')';
@@ -500,7 +505,7 @@ class Query
             // don't quote it
             $order = ' ORDER BY ' . $this->sort_by . ' ' . $this->order;
         } else {
-            $order = ' ORDER BY `' . $this->sort_by . '` ' . $this->order;
+            $order = ' ORDER BY `' . $model::get_column_name( $this->sort_by ) . '` ' . $this->order;
         }
 
         // Limit
@@ -518,6 +523,8 @@ class Query
             return apply_filters('wporm_count_query', "SELECT COUNT(*) FROM `{$table}`{$where}", $this->model);
         }
 
-        return apply_filters('wporm_query', "SELECT * FROM `{$table}`{$where}{$order}{$limit}{$offset}", $this->model);
+		$column_string = $model::get_column_string();
+
+        return apply_filters('wporm_query', "SELECT {$column_string} FROM `{$table}`{$where}{$order}{$limit}{$offset}", $this->model);
     }
 }


### PR DESCRIPTION
We often use tables that are outside of WP and are sometimes subjected to silliness such as column names with spaces that won't translate directly to PHP class properties. I added a rudimentary way of defining column aliases that seems to work well enough for Models and Queries in WP-ORM. The properties will all exist as the aliased names and will only get transformed when the queries happen.

Here's an example model definition using aliases:

`
<?php

namespace WordPress\ORM;

class WPI_Model_ProductInfo extends BaseModel {

	protected $uuid;
	protected $sku;
	protected $title;
	protected $description;
	protected $short_description;
	protected $distributor_discount;
	protected $image_url;
	protected $meta_cas_no;
	protected $meta_chemical_name;
	protected $meta_iupac_name;
	protected $meta_synonym;
	protected $meta_formula_html;
	protected $meta_formula_wt;
	protected $meta_melting_point;
	protected $meta_purity;
	protected $meta_solubility;
	protected $meta_appearance;
	protected $meta_stability;
	protected $meta_storage_temp;
	protected $meta_shipping_temp;
	protected $meta_msds_url;
	protected $meta_references;

	public static function get_column_aliases() {
		static $aliases = array(
			    'uuid' => '__kp_ProductUUID',
			    'sku' => '__kp_ProductID', 
                'title' => 'ProductName',
                'description' => 'ProductDescription',
				'short_description' => 'ShortDescription',
                'distributor_discount' => 'DistributorDiscount',
				'image_url' => 'Structure_ImageURL',
				'meta_cas_no' => 'CAS_No',
				'meta_chemical_name' => 'ChemicalName',
				'meta_iupac_name' => 'IUPAC_Name',
				'meta_synonym' => 'Synonym',
				'meta_formula_html' => 'FormulaTextHTML',
				'meta_formula_wt' => 'FormulaWt',
				'meta_melting_point' => 'MeltingPoint',
				'meta_purity' => 'Purity',
				'meta_solubility' => 'Solubility',
				'meta_appearance' => 'Appearance',
				'meta_stability' => 'Stability',
				'meta_storage_temp' => 'StorageTempShortTerm',
				'meta_shipping_temp' => 'ShippingTemp',
				'meta_msds_url' => 'MSDS_URL',
				'meta_references' => 'References',
		);
		return $aliases;
	}

    public static function get_primary_key() {
        return 'uuid';
    }

    public static function get_table() {
		global $wpdb;
        return "{$wpdb->prefix}wpi_product_information";
    }

    public static function get_searchable_fields() {
        return array();
    }
}
`

Also, I had to remove the (int) cast on the primary key as I've also encountered tables that don't use a numeric primary key :-/

Please test and give feedback!